### PR TITLE
Add Confidence Threshold

### DIFF
--- a/example.php
+++ b/example.php
@@ -31,5 +31,5 @@ var_dump($spamProtector->checkUsername("spammer4"));
 
 // If the frequency is less than the frequency threshold - Return as not spam
 // If the frequency is more than the frequency threshold, but the confidence is less than the confidence threshold - Return as not spam
-// If the frequest is more than the frequency threshold and the confidence is more than the confidence threshold - Return as spam
+// If the frequency is more than the frequency threshold and the confidence is more than the confidence threshold - Return as spam
 $spamProtector = new SpamProtection(SpamProtection::THRESHOLD_STRICT, SpamProtection::TOR_DISALLOW, null, SpamProtection::CONFIDENCE_LOW);

--- a/example.php
+++ b/example.php
@@ -25,3 +25,11 @@ var_dump($spamProtector->checkUsername("spammer2"));
 var_dump($spamProtector->checkUsername("spammer3"));
 
 var_dump($spamProtector->checkUsername("spammer4"));
+
+
+/* Confidence Threshold */
+
+// If the frequency is less than the frequency threshold - Return as not spam
+// If the frequency is more than the frequency threshold, but the confidence is less than the confidence threshold - Return as not spam
+// If the frequest is more than the frequency threshold and the confidence is more than the confidence threshold - Return as spam
+$spamProtector = new SpamProtection(SpamProtection::THRESHOLD_STRICT, SpamProtection::TOR_DISALLOW, null, SpamProtection::CONFIDENCE_LOW);

--- a/src/SpamProtection.php
+++ b/src/SpamProtection.php
@@ -147,7 +147,7 @@ class SpamProtection
         $fullApiUrl = $this->buildUrl($type, $value);
         $response = $this->sendRequest($fullApiUrl);
 
-        if (! $response) {
+        if (!$response) {
             throw new \Exception("API Check Unsuccessful");
         }
 
@@ -155,7 +155,7 @@ class SpamProtection
         if (!$json || !is_object($json)) {
             throw new \Exception("API Check Unsuccessful");
         }
-        // var_dump($json->{$type}->frequency, $json->{$type}->confidence);
+
         if ($json->success == 1 && $json->{$type}->appears == 1) {
             // Frequency Threshold check
             if ($json->{$type}->frequency < $this->frequencyThreshold) {


### PR DESCRIPTION
Hey @HelgeSverre,

The PR adds the confidence threshold (disabled by default, but as a new parameter when constructing the instance). I added an example into the examples.php showing how to set the confidence threshold, and added a few comments above the example explaining how it works. Let me know what you think, I can add some unit tests if you'd like?