### PR TITLE
Remove hardcoded version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "helgesverre/spamprotection",
   "description": "A Spam Protection class for use in contact forms and comment fields, uses the StopForumSpam API.  ",
-  "version": "1.0.1",
   "type": "library",
   "keywords": [
     "spam",


### PR DESCRIPTION
Fixes this issue (`composer validate`):
<img width="956" height="70" alt="image" src="https://github.com/user-attachments/assets/c2b21ace-c227-47f5-a03a-4d9f1e53de4e" />
