### PR TITLE
SpamProjector now throws custom exceptions for easier top identifying exceptions

### DIFF
--- a/src/Exception/ApiCheckException.php
+++ b/src/Exception/ApiCheckException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Helge\SpamProtection\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * Thrown when the API check fails or returns an unexpected response.
+ */
+class ApiCheckException extends Exception
+{
+    public function __construct(int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct('API Check Unsuccessful', $code, $previous);
+    }
+}

--- a/src/Exception/ApiKeyMissingException.php
+++ b/src/Exception/ApiKeyMissingException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Helge\SpamProtection\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * Thrown when an API key is required but not provided.
+ */
+class ApiKeyMissingException extends Exception
+{
+    public function __construct(int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct(
+            'To submit a spam report you need an API Key',
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/Exception/SubmissionFailedException.php
+++ b/src/Exception/SubmissionFailedException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Helge\SpamProtection\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * Thrown when a spam report submission fails.
+ */
+class SubmissionFailedException extends Exception
+{
+    public function __construct(int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct('Submission failed.', $code, $previous);
+    }
+}

--- a/src/SpamProtection.php
+++ b/src/SpamProtection.php
@@ -2,6 +2,10 @@
 
 namespace Helge\SpamProtection;
 
+use Helge\SpamProtection\Exception\ApiCheckException;
+use Helge\SpamProtection\Exception\ApiKeyMissingException;
+use Helge\SpamProtection\Exception\SubmissionFailedException;
+
 // TODO(25 okt 2015) ~ Helge: add support for a "last seen" cutoff
 
 /**
@@ -148,12 +152,12 @@ class SpamProtection
         $response = $this->sendRequest($fullApiUrl);
 
         if (!$response) {
-            throw new \Exception("API Check Unsuccessful");
+            throw new ApiCheckException();
         }
 
         $json = json_decode($response);
         if (!$json || !is_object($json)) {
-            throw new \Exception("API Check Unsuccessful");
+            throw new ApiCheckException();
         }
 
         if ($json->success == 1 && $json->{$type}->appears == 1) {
@@ -228,7 +232,7 @@ class SpamProtection
     {
 
         if (!$this->apiKey) {
-            throw new \Exception("To submit a spam report you need an API Key");
+            throw new ApiKeyMissingException();
         }
 
         $apiUrl = "http://www.stopforumspam.com/add.php"
@@ -243,7 +247,7 @@ class SpamProtection
         if (preg_match('/data submitted successfully/', $response)) {
             return true;
         } else {
-            throw new \Exception("Submission failed.");
+            throw new SubmissionFailedException();
         }
     }
 


### PR DESCRIPTION
Having custom exceptions makes it easier to identify the cause in try-catch blocks, so this PR adds this functionality.

P.S. It might be a good idea to merge #7 first, as this PR uses PHP 8 coding style.